### PR TITLE
Fix code listing

### DIFF
--- a/Docs/guides/Game Objects.md
+++ b/Docs/guides/Game Objects.md
@@ -11,10 +11,10 @@ You should subclass `GameObject` to provide convenient initialization of commonl
 This pattern effectively functions as a factory system (as nothing beside a initializer is modified), but has the added benefit of associating a type to the instances you create. This way, you can still make natural queries about the kinds of things in the game: `if hitObject is Astroid { ... }`.
 
 For example:
+
 	class PlayerSpaceship : GameObject {
 	    override init() {
 	        super.init()  // required
-	
 	        // define components
 	        let movement = MovementComponent()
 	        movement.speed = 10


### PR DESCRIPTION
In [GameObjects.md](https://github.com/Samasaur1/AntlerKit/blob/7f67b95bf323ec24f58ab1d7f840f082cbe58a4d/Docs/guides/Game%20Objects.md), in `Docs/guides/`, there was a code listing. However, it appeared to be improperly rendered. I think this is what you meant to have